### PR TITLE
Default brokers to port 9092 if not specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,6 +83,13 @@ func parseArgs() {
 	}
 
 	config.brokers = strings.Split(brokersString, ",")
+	
+	for i := range brokers {
+		if !strings.Contains(brokers[i], ":") {
+			brokers[i] = brokers[i] + ":9092"
+		}
+	}
+	
 	offsets := strings.Split(offset, ":")
 
 	switch {


### PR DESCRIPTION
Only tested in the Go playground: https://play.golang.org/p/Ixz8had8f6

Not sure if you want to make `9092` a constant.