### PR TITLE
Add `kt list` to show all available topics

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -32,6 +32,10 @@ func consumerCommand() command {
 		parseArgs: func(args []string) {
 			var err error
 
+			if len(args) == 0 {
+				consume.Usage()
+			}
+
 			consume.Parse(args)
 
 			failStartup := func(msg string) {

--- a/list.go
+++ b/list.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/Shopify/sarama"
+)
+
+func listCommand() command {
+	list := flag.NewFlagSet("list", flag.ExitOnError)
+	list.StringVar(&config.list.args.brokers, "brokers", "localhost:9092", "Comma separated list of brokers. Port defaults to 9092 when omitted.")
+
+	list.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage of list:")
+		list.PrintDefaults()
+		os.Exit(2)
+	}
+
+	return command{
+		flags: list,
+		parseArgs: func(args []string) {
+
+			list.Parse(args)
+
+			config.list.brokers = strings.Split(config.list.args.brokers, ",")
+			for i, b := range config.list.brokers {
+				if !strings.Contains(b, ":") {
+					config.list.brokers[i] = b + ":9092"
+				}
+			}
+		},
+
+		run: func(closer chan struct{}) {
+
+			client, err := sarama.NewClient(config.list.brokers, nil)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to create client err=%v\n", err)
+				os.Exit(1)
+			}
+			defer client.Close()
+
+			topics, err := client.Topics()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to read topics err=%v\n", err)
+				os.Exit(1)
+			}
+
+			sort.Strings(topics)
+
+			for _, topic := range topics {
+				fmt.Println(topic)
+			}
+		},
+	}
+}

--- a/main.go
+++ b/main.go
@@ -27,8 +27,16 @@ type consumerConfig struct {
 	}
 }
 
+type listConfig struct {
+	brokers []string
+	args    struct {
+		brokers string
+	}
+}
+
 var config struct {
 	consume consumerConfig
+	list    listConfig
 }
 
 func listenForInterrupt() chan struct{} {
@@ -83,6 +91,7 @@ Usage:
 The commands are:
 
 	consume        consume messages.
+	list           list topics.
 
 Use "kt [command] -help" for for information about the command.
 
@@ -100,15 +109,12 @@ func parseArgs() command {
 
 	commands := map[string]command{
 		"consume": consumerCommand(),
+		"list":    listCommand(),
 	}
 
 	cmd, ok := commands[os.Args[1]]
 	if !ok {
 		usage()
-	}
-
-	if len(os.Args) == 2 {
-		cmd.flags.Usage()
 	}
 
 	cmd.parseArgs(os.Args[2:])


### PR DESCRIPTION
Equivalent to `bin/kafka-topics.sh --list`.

You might want to consider renaming `list` to `meta` or `topics` or something so that you can add more commands under this subcommand in the future, e.g., the equivalent of `bin/kafka-topics.sh --describe --topic <name>`.

Somewhat a start on #5.