### PR TITLE
Add support for Windows usernames

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -271,7 +271,7 @@ func (cmd *consumeCmd) setupClient() {
 	if usr, err = user.Current(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to read current user err=%v", err)
 	}
-	cfg.ClientID = "kt-consume-" + usr.Username
+	cfg.ClientID = "kt-consume-" + sanitizeUsername(usr.Username)
 	if cmd.verbose {
 		fmt.Fprintf(os.Stderr, "sarama client configuration %#v\n", cfg)
 	}

--- a/offset.go
+++ b/offset.go
@@ -128,7 +128,7 @@ func (cmd *offsetCmd) connect() {
 	if usr, err = user.Current(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to read current user err=%v", err)
 	}
-	cfg.ClientID = "kt-offset-" + usr.Username
+	cfg.ClientID = "kt-offset-" + sanitizeUsername(usr.Username)
 
 	if cmd.verbose {
 		fmt.Fprintf(os.Stderr, "sarama client configuration %#v\n", cfg)

--- a/produce.go
+++ b/produce.go
@@ -147,7 +147,7 @@ func (cmd *produceCmd) findLeaders() {
 	if usr, err = user.Current(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to read current user err=%v", err)
 	}
-	cfg.ClientID = "kt-produce-" + usr.Username
+	cfg.ClientID = "kt-produce-" + sanitizeUsername(usr.Username)
 	if cmd.verbose {
 		fmt.Fprintf(os.Stderr, "sarama client configuration %#v\n", cfg)
 	}

--- a/topic.go
+++ b/topic.go
@@ -122,7 +122,7 @@ func (cmd *topicCmd) connect() {
 	if usr, err = user.Current(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to read current user err=%v", err)
 	}
-	cfg.ClientID = "kt-topic-" + usr.Username
+	cfg.ClientID = "kt-topic-" + sanitizeUsername(usr.Username)
 	if cmd.verbose {
 		fmt.Fprintf(os.Stderr, "sarama client configuration %#v\n", cfg)
 	}


### PR DESCRIPTION
Windows usernames may contain invalid characters that would prevent it from being used in ClientID.