### PR TITLE
Protobuf support

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -20,17 +20,19 @@ import (
 )
 
 type consumeCmd struct {
-	topic       string
-	brokers     []string
-	offsets     map[int32]interval
-	timeout     time.Duration
-	verbose     bool
-	version     sarama.KafkaVersion
-	encodeValue string
-	encodeKey   string
-
-	client   sarama.Client
-	consumer sarama.Consumer
+	topic         string
+	brokers       []string
+	offsets       map[int32]interval
+	timeout       time.Duration
+	verbose       bool
+	version       sarama.KafkaVersion
+	encodeValue   string
+	encodeKey     string
+	protobuffType string
+	rpcProcessCmd string
+	client        sarama.Client
+	consumer      sarama.Consumer
+	protoDecoder  *ProtoDecoder
 
 	q chan struct{}
 }
@@ -72,14 +74,16 @@ type interval struct {
 }
 
 type consumeArgs struct {
-	topic       string
-	brokers     string
-	timeout     time.Duration
-	offsets     string
-	verbose     bool
-	version     string
-	encodeValue string
-	encodeKey   string
+	topic         string
+	brokers       string
+	timeout       time.Duration
+	offsets       string
+	verbose       bool
+	version       string
+	encodeValue   string
+	encodeKey     string
+	rpcProcessCmd string
+	pType         string
 }
 
 func parseOffset(str string) (offset, error) {
@@ -205,11 +209,18 @@ func (cmd *consumeCmd) parseArgs(as []string) {
 	cmd.verbose = args.verbose
 	cmd.version = kafkaVersion(args.version)
 
-	if args.encodeValue != "string" && args.encodeValue != "hex" && args.encodeValue != "base64" {
-		cmd.failStartup(fmt.Sprintf(`unsupported encodevalue argument %#v, only string, hex and base64 are supported.`, args.encodeValue))
+	if args.encodeValue != "string" && args.encodeValue != "hex" && args.encodeValue != "base64" && args.encodeValue != "proto" {
+		cmd.failStartup(fmt.Sprintf(`unsupported encodevalue argument %#v, only string, hex, base64 and proto are supported.`, args.encodeValue))
 		return
 	}
+	if args.encodeValue == "proto" && (args.pType == "" || args.rpcProcessCmd == "") {
+		cmd.failStartup("-ptype and -rpcprocesscmd arguments must be specified if encodevalue is proto")
+		return
+	}
+
 	cmd.encodeValue = args.encodeValue
+	cmd.protobuffType = args.pType
+	cmd.rpcProcessCmd = args.rpcProcessCmd
 
 	if args.encodeKey != "string" && args.encodeKey != "hex" && args.encodeKey != "base64" {
 		cmd.failStartup(fmt.Sprintf(`unsupported encodekey argument %#v, only string, hex and base64 are supported.`, args.encodeValue))
@@ -247,9 +258,10 @@ func (cmd *consumeCmd) parseFlags(as []string) consumeArgs {
 	flags.DurationVar(&args.timeout, "timeout", time.Duration(0), "Timeout after not reading messages (default 0 to disable).")
 	flags.BoolVar(&args.verbose, "verbose", false, "More verbose logging to stderr.")
 	flags.StringVar(&args.version, "version", "", "Kafka protocol version")
-	flags.StringVar(&args.encodeValue, "encodevalue", "string", "Present message value as (string|hex|base64), defaults to string.")
+	flags.StringVar(&args.encodeValue, "encodevalue", "string", "Present message value as (string|hex|base64|binary|proto), defaults to string.")
 	flags.StringVar(&args.encodeKey, "encodekey", "string", "Present message key as (string|hex|base64), defaults to string.")
-
+	flags.StringVar(&args.pType, "ptype", "", "Protobuff type name to be used for decoding encodevalue=proto")
+	flags.StringVar(&args.rpcProcessCmd, "rpcprocesscmd", "", "command to run to start RPC process for protobuff deserialization")
 	flags.Usage = func() {
 		fmt.Fprintln(os.Stderr, "Usage of consume:")
 		flags.PrintDefaults()
@@ -278,6 +290,13 @@ func (cmd *consumeCmd) setupClient() {
 
 	if cmd.client, err = sarama.NewClient(cmd.brokers, cfg); err != nil {
 		failf("failed to create client err=%v", err)
+	}
+	if cmd.encodeValue == "proto" {
+		client, err := MustNewProtoDecoder(cmd.rpcProcessCmd, "tcp", "localhost:8080")
+		if err != nil {
+			failf("failed to create client to talk to proto decoder", err)
+		}
+		cmd.protoDecoder = client
 	}
 }
 
@@ -382,6 +401,9 @@ type printContext struct {
 
 func (cmd *consumeCmd) partitionLoop(out chan printContext, pc sarama.PartitionConsumer, p int32, end int64) {
 	defer logClose(fmt.Sprintf("partition consumer %v", p), pc)
+	if cmd.encodeValue == "proto" {
+		defer cmd.protoDecoder.Close()
+	}
 	var (
 		timer   *time.Timer
 		timeout = make(<-chan time.Time)
@@ -429,6 +451,14 @@ func (cmd *consumeCmd) partitionLoop(out chan printContext, pc sarama.PartitionC
 			case "base64":
 				str := base64.StdEncoding.EncodeToString(msg.Value)
 				m.Value = &str
+			case "proto":
+				protoMsg, err := cmd.protoDecoder.DeserializeAny(cmd.protobuffType, msg.Value)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Quitting due to unexpected error protobuff deserialization: %v\n", err)
+					close(cmd.q)
+					return
+				}
+				m.Value = &protoMsg
 			}
 			switch cmd.encodeKey {
 			case "hex":
@@ -438,7 +468,6 @@ func (cmd *consumeCmd) partitionLoop(out chan printContext, pc sarama.PartitionC
 				str := base64.StdEncoding.EncodeToString(msg.Key)
 				m.Key = &str
 			}
-
 			if buf, err = json.Marshal(m); err != nil {
 				fmt.Fprintf(os.Stderr, "Quitting due to unexpected error during marshal: %v\n", err)
 				close(cmd.q)

--- a/proto.go
+++ b/proto.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"errors"
+	"net/rpc"
+	"os/exec"
+)
+
+// Args is a predefined contract struct between client and remote process for arguments
+type Args struct {
+	TypeName string
+	Data     []byte
+}
+
+// ProtoDecoder is a struct that holds the rpc client and the cmd that started the RPC process
+type ProtoDecoder struct {
+	rpcClient  *rpc.Client
+	rpcProcess *exec.Cmd
+}
+
+// DeserializeAny tries to deserialize a given byte array of data into a proto.Message specified by given typeName via an RPC
+func (c *ProtoDecoder) DeserializeAny(typeName string, data []byte) (string, error) {
+
+	args := &Args{
+		TypeName: typeName,
+		Data:     data,
+	}
+	var str string
+	err := c.rpcClient.Call("ProtoDeserializer.DeserializeAny", args, &str)
+	if err != nil {
+		return "", err
+	}
+	return str, nil
+}
+
+// MustNewProtoDecoder returns a new ProtoDecoder by execing a new RPC decoder and initializing a new rpc.client to talk to decoder
+func MustNewProtoDecoder(command, network, address string) (*ProtoDecoder, error) {
+
+	cmd := exec.Command(command)
+	err := cmd.Start()
+
+	if err != nil {
+		return nil, errors.New("Failed to exec RPC decoder. " + err.Error())
+	}
+	client, err := rpc.DialHTTP(network, address)
+	if err != nil {
+		return nil, err
+	}
+	return &ProtoDecoder{
+		client,
+		cmd,
+	}, nil
+
+}
+
+// Close terminates both the RPC client and RPC process
+func (c *ProtoDecoder) Close() error {
+	if err := c.rpcClient.Close(); err != nil {
+		return errors.New("Failed to close rpc client. " + err.Error())
+	}
+
+	if err := c.rpcProcess.Process.Kill(); err != nil {
+		return errors.New("Failed to kill rpc process. " + err.Error())
+	}
+	return nil
+}


### PR DESCRIPTION
This is a potential solution for KT to support protobuff deserialization by having KT start up an external GO RPC process that handles deserialization, and making calls to it.

My first solution involved having KT import the go types directly so that types are built as part of KT. Lots of problems with this not least of which is exposing internal types to an open source proj :D

I know this is not perfect, but perhaps it will open up a discussion. Jerry suggests this is too coupled to go, where as a solution using pipes or unix sockets would allow the deserialiser to be done in any language.

Example of the external RPC process code: https://gist.github.com/jackyzhen/7ea365e7513440a31daf71b9674714fe