### PR TITLE
group: reset all partitions if invoked with -partition -1

### DIFF
--- a/group.go
+++ b/group.go
@@ -180,20 +180,20 @@ func (cmd *groupCmd) fetchGroupOffset(wg *sync.WaitGroup, grp, top string, part 
 	}
 
 	if cmd.reset >= 0 || cmd.reset == sarama.OffsetNewest || cmd.reset == sarama.OffsetOldest {
-		rst := cmd.reset
-		switch rst {
+		resolvedOff := cmd.reset
+		switch resolvedOff {
 		case sarama.OffsetNewest, sarama.OffsetOldest:
 			off, err := cmd.client.GetOffset(top, part, cmd.reset)
 			if err != nil {
-				failf("failed to get offset to reset to err=%v", err)
+				failf("failed to get offset to reset to for partition=%d err=%v", part, err)
 			}
-			rst = off
+			resolvedOff = off
 			if cmd.verbose {
-				fmt.Fprintf(os.Stderr, "resolved reset offset to %v", rst)
+				fmt.Fprintf(os.Stderr, "resolved reset offset for partition=%d to %v", part, resolvedOff)
 			}
 		}
-		groupOff = rst
-		pom.MarkOffset(rst, "")
+		groupOff = resolvedOff
+		pom.MarkOffset(resolvedOff, "")
 	}
 
 	if partOff, err = cmd.client.GetOffset(top, part, sarama.OffsetNewest); err != nil {

--- a/group.go
+++ b/group.go
@@ -180,19 +180,20 @@ func (cmd *groupCmd) fetchGroupOffset(wg *sync.WaitGroup, grp, top string, part 
 	}
 
 	if cmd.reset >= 0 || cmd.reset == sarama.OffsetNewest || cmd.reset == sarama.OffsetOldest {
-		switch cmd.reset {
+		rst := cmd.reset
+		switch rst {
 		case sarama.OffsetNewest, sarama.OffsetOldest:
 			off, err := cmd.client.GetOffset(top, part, cmd.reset)
 			if err != nil {
 				failf("failed to get offset to reset to err=%v", err)
 			}
-			cmd.reset = off
+			rst = off
 			if cmd.verbose {
-				fmt.Fprintf(os.Stderr, "resolved reset offset to %v", cmd.reset)
+				fmt.Fprintf(os.Stderr, "resolved reset offset to %v", rst)
 			}
 		}
-		groupOff = cmd.reset
-		pom.MarkOffset(cmd.reset, "")
+		groupOff = rst
+		pom.MarkOffset(rst, "")
 	}
 
 	if partOff, err = cmd.client.GetOffset(top, part, sarama.OffsetNewest); err != nil {


### PR DESCRIPTION
I'm new to Kafka (long time Kinesis user) so take this PR with a grain of salt :)
I thought that maybe you wouldn't want an implicit match-all-partitions logic in a potentially destructive (well, write) operation, so came up with the "-1" magic number. Maybe the `-partition` param can be a string, then it would accept `all` for all partitions etc.