### PR TITLE
fix build failure on Windows

### DIFF
--- a/common.go
+++ b/common.go
@@ -72,7 +72,7 @@ func print(in <-chan printContext, pretty bool) {
 		marshal = json.Marshal
 	)
 
-	if pretty && terminal.IsTerminal(syscall.Stdout) {
+	if pretty && terminal.IsTerminal(int(syscall.Stdout)) {
 		marshal = func(i interface{}) ([]byte, error) { return json.MarshalIndent(i, "", "  ") }
 	}
 


### PR DESCRIPTION
Hey Felix :) Small fix for the tool, maybe some Windows users exist out there.

error was:
.\common.go:75: cannot use syscall.Stdout (type syscall.Handle) as type int in argument to terminal.IsTerminal

found solution here:
https://github.com/golang/go/issues/12978#issuecomment-149035393

tested both terminal and non terminal :)

$ ./kt consume -pretty -topic WordsWithCountsTopic
{
  "partition": 0,
  "offset": 0,
  "key": "",
  "value": "1"
}
$ ./kt consume -pretty -topic WordsWithCountsTopic > x
$ cat x
{"partition":0,"offset":0,"key":"","value":"1"}