### PR TITLE
go1.10.1 complains about newline and unrecognized format string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: go
 
 go:
-  - 1.9
+  - 1.10.1
 
 install:
 - curl -sSL "https://get.docker.com/gpg" | sudo -E apt-key add -

--- a/system_test.go
+++ b/system_test.go
@@ -149,6 +149,6 @@ func TestSystem(t *testing.T) {
 		if l == "" { // final newline
 			continue
 		}
-		require.JSONEq(t, expectedLines[i-1], l, fmt.Sprintf("line %d", i-1))
+		require.JSONEq(t, expectedLines[i-1], l, fmt.Sprintf("line %i", i-1))
 	}
 }

--- a/system_test.go
+++ b/system_test.go
@@ -149,6 +149,6 @@ func TestSystem(t *testing.T) {
 		if l == "" { // final newline
 			continue
 		}
-		require.JSONEq(t, expectedLines[i-1], l, fmt.Sprintf("line %i", i-1))
+		require.JSONEq(t, expectedLines[i-1], l, fmt.Sprintf("line %d", i-1))
 	}
 }

--- a/topic.go
+++ b/topic.go
@@ -70,8 +70,7 @@ func (cmd *topicCmd) parseFlags(as []string) topicArgs {
 		flags.PrintDefaults()
 		fmt.Fprintln(os.Stderr, `
 The values for -brokers can also be set via the environment variable KT_BROKERS respectively.
-The values supplied on the command line win over environment variable values.
-`)
+The values supplied on the command line win over environment variable values.`)
 		os.Exit(2)
 	}
 

--- a/topic.go
+++ b/topic.go
@@ -70,7 +70,8 @@ func (cmd *topicCmd) parseFlags(as []string) topicArgs {
 		flags.PrintDefaults()
 		fmt.Fprintln(os.Stderr, `
 The values for -brokers can also be set via the environment variable KT_BROKERS respectively.
-The values supplied on the command line win over environment variable values.`)
+The values supplied on the command line win over environment variable values.
+`)
 		os.Exit(2)
 	}
 


### PR DESCRIPTION
Seems that the go compiler is getting a little bit more stringent!

Happy to add a better commit message if you'd prefer