### PR TITLE
sort group partitions by partition index

### DIFF
--- a/group.go
+++ b/group.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/user"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -141,6 +142,9 @@ awaitGroupOffsets:
 	}
 
 	if len(target.Offsets) > 0 {
+		sort.Slice(target.Offsets, func(i, j int) bool {
+			return target.Offsets[j].Partition > target.Offsets[i].Partition
+		})
 		ctx := printContext{output: target, done: make(chan struct{})}
 		out <- ctx
 		<-ctx.done


### PR DESCRIPTION
Make it so the output from the topic command group display partitions in same order