### PR TITLE
Make admin timeout configurable

### DIFF
--- a/common.go
+++ b/common.go
@@ -46,6 +46,19 @@ func kafkaVersion(s string) sarama.KafkaVersion {
 	return v
 }
 
+func parseTimeout(s string) *time.Duration {
+	if s == "" {
+		return nil
+	}
+
+	v, err := time.ParseDuration(s)
+	if err != nil {
+		failf(err.Error())
+	}
+
+	return &v
+}
+
 func logClose(name string, c io.Closer) {
 	if err := c.Close(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to close %#v err=%v", name, err)


### PR DESCRIPTION
I have implement recently a simple shell script wrapper which uses `kt` and provides capabilities to use migrations (sort of) with Kafka, like automatic topics creation/deletion/reconfiguration, etc.

There is a common situation to create a lot of topics and during that Kafka may answer a little bit longer, which causes all subsequent operation to fail with the following error:
```
failed to create topic err=kafka server: Request exceeded the user-specified time limit in the request.
```

The default limit is `3s` [in Sarama](https://github.com/fgeller/kt/blob/27b8aca81b3cee5e18b1e005709a67e70cb16c3e/vendor/github.com/Shopify/sarama/config.go#L343), and it happens to be not enough quite often.

I've added the ability to configure this timeout via `-timeout` flag of `kt admin` command, or via `KT_ADMIN_TIMEOUT` env var globally.