### PR TITLE
Use `-tls` to enable 1-way TLS (no client authentication)

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -15,13 +15,14 @@ import (
 )
 
 type adminCmd struct {
-	brokers    []string
-	verbose    bool
-	version    sarama.KafkaVersion
-	timeout    *time.Duration
-	tlsCA      string
-	tlsCert    string
-	tlsCertKey string
+	brokers     []string
+	verbose     bool
+	version     sarama.KafkaVersion
+	timeout     *time.Duration
+	tlsExpected bool
+	tlsCA       string
+	tlsCert     string
+	tlsCertKey  string
 
 	createTopic  string
 	topicDetail  *sarama.TopicDetail
@@ -32,13 +33,14 @@ type adminCmd struct {
 }
 
 type adminArgs struct {
-	brokers    string
-	verbose    bool
-	version    string
-	timeout    string
-	tlsCA      string
-	tlsCert    string
-	tlsCertKey string
+	brokers     string
+	verbose     bool
+	version     string
+	timeout     string
+	tlsExpected bool
+	tlsCA       string
+	tlsCert     string
+	tlsCertKey  string
 
 	createTopic     string
 	topicDetailPath string
@@ -59,6 +61,7 @@ func (cmd *adminCmd) parseArgs(as []string) {
 		cmd.timeout = parseTimeout(args.timeout)
 	}
 
+	cmd.tlsExpected = args.tlsExpected
 	cmd.tlsCA = args.tlsCA
 	cmd.tlsCert = args.tlsCert
 	cmd.tlsCertKey = args.tlsCertKey
@@ -150,7 +153,7 @@ func (cmd *adminCmd) saramaConfig() *sarama.Config {
 		cfg.Admin.Timeout = *cmd.timeout
 	}
 
-	tlsConfig, err := setupCerts(cmd.tlsCert, cmd.tlsCA, cmd.tlsCertKey)
+	tlsConfig, err := setupCerts(cmd.tlsExpected, cmd.tlsCert, cmd.tlsCA, cmd.tlsCertKey)
 	if err != nil {
 		failf("failed to setup certificates err=%v", err)
 	}
@@ -169,6 +172,7 @@ func (cmd *adminCmd) parseFlags(as []string) adminArgs {
 	flags.BoolVar(&args.verbose, "verbose", false, "More verbose logging to stderr.")
 	flags.StringVar(&args.version, "version", "", "Kafka protocol version")
 	flags.StringVar(&args.timeout, "timeout", "", "Timeout for request to Kafka (default: 3s)")
+	flags.BoolVar(&args.tlsExpected, "tls", false, "Turn on server-only TLS if no certificate provided")
 	flags.StringVar(&args.tlsCA, "tlsca", "", "Path to the TLS certificate authority file")
 	flags.StringVar(&args.tlsCert, "tlscert", "", "Path to the TLS client certificate file")
 	flags.StringVar(&args.tlsCertKey, "tlscertkey", "", "Path to the TLS client certificate key file")

--- a/common.go
+++ b/common.go
@@ -177,8 +177,14 @@ func randomString(length int) string {
 
 // setupCerts takes the paths to a tls certificate, CA, and certificate key in
 // a PEM format and returns a constructed tls.Config object.
-func setupCerts(certPath, caPath, keyPath string) (*tls.Config, error) {
+func setupCerts(tlsExpected bool, certPath, caPath, keyPath string) (*tls.Config, error) {
 	if certPath == "" && caPath == "" && keyPath == "" {
+		// If TLS is expected, return empty tls.Config.  This enables one-way authentication
+		// if kafka configured with ssl.client.auth=requested
+		if tlsExpected {
+			return &tls.Config{}, nil
+		}
+
 		return nil, nil
 	}
 

--- a/consume.go
+++ b/consume.go
@@ -22,6 +22,7 @@ type consumeCmd struct {
 
 	topic       string
 	brokers     []string
+	tlsExpected bool
 	tlsCA       string
 	tlsCert     string
 	tlsCertKey  string
@@ -88,6 +89,7 @@ type interval struct {
 type consumeArgs struct {
 	topic       string
 	brokers     string
+	tlsExpected bool
 	tlsCA       string
 	tlsCert     string
 	tlsCertKey  string
@@ -270,6 +272,7 @@ func (cmd *consumeCmd) parseFlags(as []string) consumeArgs {
 	flags := flag.NewFlagSet("consume", flag.ContinueOnError)
 	flags.StringVar(&args.topic, "topic", "", "Topic to consume (required).")
 	flags.StringVar(&args.brokers, "brokers", "", "Comma separated list of brokers. Port defaults to 9092 when omitted (defaults to localhost:9092).")
+	flags.BoolVar(&args.tlsExpected, "tls", false, "Turn on server-only TLS if no certificate provided")
 	flags.StringVar(&args.tlsCA, "tlsca", "", "Path to the TLS certificate authority file")
 	flags.StringVar(&args.tlsCert, "tlscert", "", "Path to the TLS client certificate file")
 	flags.StringVar(&args.tlsCertKey, "tlscertkey", "", "Path to the TLS client certificate key file")
@@ -312,7 +315,7 @@ func (cmd *consumeCmd) setupClient() {
 	if cmd.verbose {
 		fmt.Fprintf(os.Stderr, "sarama client configuration %#v\n", cfg)
 	}
-	tlsConfig, err := setupCerts(cmd.tlsCert, cmd.tlsCA, cmd.tlsCertKey)
+	tlsConfig, err := setupCerts(cmd.tlsExpected, cmd.tlsCert, cmd.tlsCA, cmd.tlsCertKey)
 	if err != nil {
 		failf("failed to setup certificates err=%v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,5 @@ require (
 	golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4
 	golang.org/x/sys v0.0.0-20181005133103-4497e2df6f9e // indirect
 )
+
+go 1.13

--- a/group.go
+++ b/group.go
@@ -17,6 +17,7 @@ import (
 
 type groupCmd struct {
 	brokers      []string
+	tlsExpected  bool
 	tlsCA        string
 	tlsCert      string
 	tlsCertKey   string
@@ -329,7 +330,7 @@ func (cmd *groupCmd) saramaConfig() *sarama.Config {
 	}
 	cfg.ClientID = "kt-group-" + sanitizeUsername(usr.Username)
 
-	tlsConfig, err := setupCerts(cmd.tlsCert, cmd.tlsCA, cmd.tlsCertKey)
+	tlsConfig, err := setupCerts(cmd.tlsExpected, cmd.tlsCert, cmd.tlsCA, cmd.tlsCertKey)
 	if err != nil {
 		failf("failed to setup certificates err=%v", err)
 	}
@@ -358,6 +359,7 @@ func (cmd *groupCmd) parseArgs(as []string) {
 	}
 
 	cmd.topic = args.topic
+	cmd.tlsExpected = args.tlsExpected
 	cmd.tlsCA = args.tlsCA
 	cmd.tlsCert = args.tlsCert
 	cmd.tlsCertKey = args.tlsCertKey
@@ -434,6 +436,7 @@ func (cmd *groupCmd) parseArgs(as []string) {
 type groupArgs struct {
 	topic        string
 	brokers      string
+	tlsExpected  bool
 	tlsCA        string
 	tlsCert      string
 	tlsCertKey   string
@@ -453,6 +456,7 @@ func (cmd *groupCmd) parseFlags(as []string) groupArgs {
 	flags := flag.NewFlagSet("group", flag.ContinueOnError)
 	flags.StringVar(&args.topic, "topic", "", "Topic to consume (required).")
 	flags.StringVar(&args.brokers, "brokers", "", "Comma separated list of brokers. Port defaults to 9092 when omitted (defaults to localhost:9092).")
+	flags.BoolVar(&args.tlsExpected, "tls", false, "Turn on server-only TLS if no certificate provided")
 	flags.StringVar(&args.tlsCA, "tlsca", "", "Path to the TLS certificate authority file")
 	flags.StringVar(&args.tlsCert, "tlscert", "", "Path to the TLS client certificate file")
 	flags.StringVar(&args.tlsCertKey, "tlscertkey", "", "Path to the TLS client certificate key file")

--- a/produce.go
+++ b/produce.go
@@ -19,6 +19,7 @@ type produceArgs struct {
 	topic       string
 	partition   int
 	brokers     string
+	tlsExpected bool
 	tlsCA       string
 	tlsCert     string
 	tlsCertKey  string
@@ -47,6 +48,7 @@ func (cmd *produceCmd) read(as []string) produceArgs {
 	flags.StringVar(&args.topic, "topic", "", "Topic to produce to (required).")
 	flags.IntVar(&args.partition, "partition", 0, "Partition to produce to (defaults to 0).")
 	flags.StringVar(&args.brokers, "brokers", "", "Comma separated list of brokers. Port defaults to 9092 when omitted (defaults to localhost:9092).")
+	flags.BoolVar(&args.tlsExpected, "tls", false, "Turn on server-only TLS if no certificate provided")
 	flags.StringVar(&args.tlsCA, "tlsca", "", "Path to the TLS certificate authority file")
 	flags.StringVar(&args.tlsCert, "tlscert", "", "Path to the TLS client certificate file")
 	flags.StringVar(&args.tlsCertKey, "tlscertkey", "", "Path to the TLS client certificate key file")
@@ -94,6 +96,7 @@ func (cmd *produceCmd) parseArgs(as []string) {
 		}
 	}
 	cmd.topic = args.topic
+	cmd.tlsExpected = args.tlsExpected
 	cmd.tlsCA = args.tlsCA
 	cmd.tlsCert = args.tlsCert
 	cmd.tlsCertKey = args.tlsCertKey
@@ -172,7 +175,7 @@ func (cmd *produceCmd) findLeaders() {
 	if cmd.verbose {
 		fmt.Fprintf(os.Stderr, "sarama client configuration %#v\n", cfg)
 	}
-	tlsConfig, err := setupCerts(cmd.tlsCert, cmd.tlsCA, cmd.tlsCertKey)
+	tlsConfig, err := setupCerts(cmd.tlsExpected, cmd.tlsCert, cmd.tlsCA, cmd.tlsCertKey)
 	if err != nil {
 		failf("failed to setup certificates err=%v", err)
 	}
@@ -237,6 +240,7 @@ loop:
 type produceCmd struct {
 	topic       string
 	brokers     []string
+	tlsExpected bool
 	tlsCA       string
 	tlsCert     string
 	tlsCertKey  string

--- a/topic.go
+++ b/topic.go
@@ -14,31 +14,33 @@ import (
 )
 
 type topicArgs struct {
-	brokers    string
-	tlsCA      string
-	tlsCert    string
-	tlsCertKey string
-	filter     string
-	partitions bool
-	leaders    bool
-	replicas   bool
-	verbose    bool
-	pretty     bool
-	version    string
+	brokers     string
+	tlsExpected bool
+	tlsCA       string
+	tlsCert     string
+	tlsCertKey  string
+	filter      string
+	partitions  bool
+	leaders     bool
+	replicas    bool
+	verbose     bool
+	pretty      bool
+	version     string
 }
 
 type topicCmd struct {
-	brokers    []string
-	tlsCA      string
-	tlsCert    string
-	tlsCertKey string
-	filter     *regexp.Regexp
-	partitions bool
-	leaders    bool
-	replicas   bool
-	verbose    bool
-	pretty     bool
-	version    sarama.KafkaVersion
+	brokers     []string
+	tlsExpected bool
+	tlsCA       string
+	tlsCert     string
+	tlsCertKey  string
+	filter      *regexp.Regexp
+	partitions  bool
+	leaders     bool
+	replicas    bool
+	verbose     bool
+	pretty      bool
+	version     sarama.KafkaVersion
 
 	client sarama.Client
 }
@@ -64,6 +66,7 @@ func (cmd *topicCmd) parseFlags(as []string) topicArgs {
 	)
 
 	flags.StringVar(&args.brokers, "brokers", "", "Comma separated list of brokers. Port defaults to 9092 when omitted.")
+	flags.BoolVar(&args.tlsExpected, "tls", false, "Turn on server-only TLS if no certificate provided")
 	flags.StringVar(&args.tlsCA, "tlsca", "", "Path to the TLS certificate authority file")
 	flags.StringVar(&args.tlsCert, "tlscert", "", "Path to the TLS client certificate file")
 	flags.StringVar(&args.tlsCertKey, "tlscertkey", "", "Path to the TLS client certificate key file")
@@ -116,6 +119,7 @@ func (cmd *topicCmd) parseArgs(as []string) {
 		failf("invalid regex for filter err=%s", err)
 	}
 
+	cmd.tlsExpected = args.tlsExpected
 	cmd.tlsCA = args.tlsCA
 	cmd.tlsCert = args.tlsCert
 	cmd.tlsCertKey = args.tlsCertKey
@@ -145,7 +149,7 @@ func (cmd *topicCmd) connect() {
 		fmt.Fprintf(os.Stderr, "sarama client configuration %#v\n", cfg)
 	}
 
-	tlsConfig, err := setupCerts(cmd.tlsCert, cmd.tlsCA, cmd.tlsCertKey)
+	tlsConfig, err := setupCerts(cmd.tlsExpected, cmd.tlsCert, cmd.tlsCA, cmd.tlsCertKey)
 	if err != nil {
 		failf("failed to setup certificates err=%v", err)
 	}


### PR DESCRIPTION
This fixes #109 by adding a `-tls` option to indicate to use tls for authentication to the kafka server without also requiring mutual authentication between server and client.
