### PR TITLE
adds common info logging func.

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -18,13 +18,13 @@ import (
 
 type consumeCmd struct {
 	sync.Mutex
+	baseCmd
 
 	topic       string
 	brokers     []string
 	auth        authConfig
 	offsets     map[int32]interval
 	timeout     time.Duration
-	verbose     bool
 	version     sarama.KafkaVersion
 	encodeValue string
 	encodeKey   string
@@ -97,7 +97,7 @@ type consumeArgs struct {
 }
 
 func (cmd *consumeCmd) failStartup(msg string) {
-	fmt.Fprintln(os.Stderr, msg)
+	warnf(msg)
 	failf("use \"kt consume -help\" for more information")
 }
 
@@ -119,8 +119,11 @@ func (cmd *consumeCmd) parseArgs(as []string) {
 	cmd.timeout = args.timeout
 	cmd.verbose = args.verbose
 	cmd.pretty = args.pretty
-	cmd.version = kafkaVersion(args.version)
 	cmd.group = args.group
+	cmd.version, err = kafkaVersion(args.version)
+	if err != nil {
+		failf("failed to read kafka version err=%v", err)
+	}
 
 	readAuthFile(args.auth, os.Getenv(ENV_AUTH), &cmd.auth)
 
@@ -393,12 +396,10 @@ func (cmd *consumeCmd) setupClient() {
 	)
 	cfg.Version = cmd.version
 	if usr, err = user.Current(); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to read current user err=%v", err)
+		cmd.infof("Failed to read current user err=%v", err)
 	}
 	cfg.ClientID = "kt-consume-" + sanitizeUsername(usr.Username)
-	if cmd.verbose {
-		fmt.Fprintf(os.Stderr, "sarama client configuration %#v\n", cfg)
-	}
+	cmd.infof("sarama client configuration %#v\n", cfg)
 
 	if err = setupAuth(cmd.auth, cfg); err != nil {
 		failf("failed to setup auth err=%v", err)
@@ -476,17 +477,17 @@ func (cmd *consumeCmd) consumePartition(out chan printContext, partition int32) 
 	}
 
 	if start, err = cmd.resolveOffset(offsets.start, partition); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to read start offset for partition %v err=%v\n", partition, err)
+		warnf("Failed to read start offset for partition %v err=%v\n", partition, err)
 		return
 	}
 
 	if end, err = cmd.resolveOffset(offsets.end, partition); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to read end offset for partition %v err=%v\n", partition, err)
+		warnf("Failed to read end offset for partition %v err=%v\n", partition, err)
 		return
 	}
 
 	if pcon, err = cmd.consumer.ConsumePartition(cmd.topic, partition, start); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to consume partition %v err=%v\n", partition, err)
+		warnf("Failed to consume partition %v err=%v\n", partition, err)
 		return
 	}
 
@@ -538,7 +539,7 @@ func (cmd *consumeCmd) closePOMs() {
 	cmd.Lock()
 	for p, pom := range cmd.poms {
 		if err := pom.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to close partition offset manager for partition %v err=%v", p, err)
+			warnf("failed to close partition offset manager for partition %v err=%v", p, err)
 		}
 	}
 	cmd.Unlock()
@@ -588,14 +589,14 @@ func (cmd *consumeCmd) partitionLoop(out chan printContext, pc sarama.PartitionC
 
 		select {
 		case <-timeout:
-			fmt.Fprintf(os.Stderr, "consuming from partition %v timed out after %s\n", p, cmd.timeout)
+			warnf("consuming from partition %v timed out after %s\n", p, cmd.timeout)
 			return
 		case err := <-pc.Errors():
-			fmt.Fprintf(os.Stderr, "partition %v consumer encountered err %s", p, err)
+			warnf("partition %v consumer encountered err %s", p, err)
 			return
 		case msg, ok := <-pc.Messages():
 			if !ok {
-				fmt.Fprintf(os.Stderr, "unexpected closed messages chan")
+				warnf("unexpected closed messages chan")
 				return
 			}
 

--- a/system_test.go
+++ b/system_test.go
@@ -152,9 +152,10 @@ func TestSystem(t *testing.T) {
 
 	status, stdOut, stdErr = newCmd().
 		run("./kt", "group",
+			"-verbose",
 			"-topic", topicName)
-	fmt.Printf(">> system test kt group -topic %v stdout:\n%s\n", topicName, stdOut)
-	fmt.Printf(">> system test kt group -topic %v stderr:\n%s\n", topicName, stdErr)
+	fmt.Printf(">> system test kt group -verbose -topic %v stdout:\n%s\n", topicName, stdOut)
+	fmt.Printf(">> system test kt group -verbose -topic %v stderr:\n%s\n", topicName, stdErr)
 	require.Zero(t, status)
 	require.Contains(t, stdErr, fmt.Sprintf("found partitions=[0] for topic=%v", topicName))
 	require.Contains(t, stdOut, fmt.Sprintf(`{"name":"hans","topic":"%v","offsets":[{"partition":0,"offset":1,"lag":0}]}`, topicName))
@@ -220,12 +221,13 @@ func TestSystem(t *testing.T) {
 
 	status, stdOut, stdErr = newCmd().
 		run("./kt", "group",
+			"-verbose",
 			"-topic", topicName,
 			"-partitions", "0",
 			"-group", "hans",
 			"-reset", "0")
-	fmt.Printf(">> system test kt group -topic %v -partitions 0 -group hans -reset 0 stdout:\n%s\n", topicName, stdOut)
-	fmt.Printf(">> system test kt group -topic %v -partitions 0 -group hans -reset 0  stderr:\n%s\n", topicName, stdErr)
+	fmt.Printf(">> system test kt group -verbose -topic %v -partitions 0 -group hans -reset 0 stdout:\n%s\n", topicName, stdOut)
+	fmt.Printf(">> system test kt group -verbose -topic %v -partitions 0 -group hans -reset 0  stderr:\n%s\n", topicName, stdErr)
 	require.Zero(t, status)
 
 	lines = strings.Split(stdOut, "\n")
@@ -249,9 +251,10 @@ func TestSystem(t *testing.T) {
 
 	status, stdOut, stdErr = newCmd().
 		run("./kt", "group",
+			"-verbose",
 			"-topic", topicName)
-	fmt.Printf(">> system test kt group -topic %v stdout:\n%s\n", topicName, stdOut)
-	fmt.Printf(">> system test kt group -topic %v stderr:\n%s\n", topicName, stdErr)
+	fmt.Printf(">> system test kt group -verbose -topic %v stdout:\n%s\n", topicName, stdOut)
+	fmt.Printf(">> system test kt group -verbose -topic %v stderr:\n%s\n", topicName, stdErr)
 	require.Zero(t, status)
 	require.Contains(t, stdErr, fmt.Sprintf("found partitions=[0] for topic=%v", topicName))
 	require.Contains(t, stdOut, fmt.Sprintf(`{"name":"hans","topic":"%v","offsets":[{"partition":0,"offset":0,"lag":2}]}`, topicName))

--- a/topic.go
+++ b/topic.go
@@ -27,6 +27,8 @@ type topicArgs struct {
 }
 
 type topicCmd struct {
+	baseCmd
+
 	brokers    []string
 	auth       authConfig
 	filter     *regexp.Regexp
@@ -34,7 +36,6 @@ type topicCmd struct {
 	leaders    bool
 	replicas   bool
 	config     bool
-	verbose    bool
 	pretty     bool
 	version    sarama.KafkaVersion
 
@@ -124,7 +125,11 @@ func (cmd *topicCmd) parseArgs(as []string) {
 	cmd.config = args.config
 	cmd.pretty = args.pretty
 	cmd.verbose = args.verbose
-	cmd.version = kafkaVersion(args.version)
+
+	cmd.version, err = kafkaVersion(args.version)
+	if err != nil {
+		failf("failed to read kafka version err=%v", err)
+	}
 }
 
 func (cmd *topicCmd) connect() {
@@ -137,12 +142,10 @@ func (cmd *topicCmd) connect() {
 	cfg.Version = cmd.version
 
 	if usr, err = user.Current(); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to read current user err=%v", err)
+		cmd.infof("Failed to read current user err=%v", err)
 	}
 	cfg.ClientID = "kt-topic-" + sanitizeUsername(usr.Username)
-	if cmd.verbose {
-		fmt.Fprintf(os.Stderr, "sarama client configuration %#v\n", cfg)
-	}
+	cmd.infof("sarama client configuration %#v\n", cfg)
 
 	setupAuth(cmd.auth, cfg)
 
@@ -201,7 +204,7 @@ func (cmd *topicCmd) print(name string, out chan printContext) {
 	)
 
 	if top, err = cmd.readTopic(name); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to read info for topic %s. err=%v\n", name, err)
+		warnf("failed to read info for topic %s. err=%v\n", name, err)
 		return
 	}
 


### PR DESCRIPTION
- less noisy output by default, -verbose for more noise cf #130
- standardizes the way fmt.Fprint* is used.
- baseCmd allows for re-use, should use it for more