### PR TITLE
Support custom CA for 1-way TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,11 +283,16 @@ Required fields:
 
  - `mode`: This needs to be set to `TLS-1way`
 
+Optional fields:
+
+ - `ca-certificate`: Path to your CA certificate
+
+
 Example:
 
 
     {
-        "mode": "TLS-1way",
+        "mode": "TLS-1way"
     }
 
 ### Other modes

--- a/common.go
+++ b/common.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"syscall"
@@ -291,6 +292,12 @@ func setupAuthTLS(auth authConfig, saramaCfg *sarama.Config) error {
 	return nil
 }
 
+func qualifyPath(argFN string, target *string) {
+	if *target != "" && !filepath.IsAbs(*target) {
+		*target = filepath.Join(filepath.Dir(argFN), *target)
+	}
+}
+
 func readAuthFile(argFN string, envFN string, target *authConfig) {
 	if argFN == "" && envFN == "" {
 		return
@@ -309,4 +316,8 @@ func readAuthFile(argFN string, envFN string, target *authConfig) {
 	if err := json.Unmarshal(byts, target); err != nil {
 		failf("failed to unmarshal auth file err=%v", err)
 	}
+
+	qualifyPath(fn, &target.CACert)
+	qualifyPath(fn, &target.ClientCert)
+	qualifyPath(fn, &target.ClientCertKey)
 }

--- a/group.go
+++ b/group.go
@@ -323,7 +323,9 @@ func (cmd *groupCmd) saramaConfig() *sarama.Config {
 	cfg.ClientID = "kt-group-" + sanitizeUsername(usr.Username)
 	cmd.infof("sarama client configuration %#v\n", cfg)
 
-	setupAuth(cmd.auth, cfg)
+	if err = setupAuth(cmd.auth, cfg); err != nil {
+		failf("failed to setup auth err=%v", err)
+	}
 
 	return cfg
 }

--- a/topic.go
+++ b/topic.go
@@ -147,7 +147,9 @@ func (cmd *topicCmd) connect() {
 	cfg.ClientID = "kt-topic-" + sanitizeUsername(usr.Username)
 	cmd.infof("sarama client configuration %#v\n", cfg)
 
-	setupAuth(cmd.auth, cfg)
+	if err = setupAuth(cmd.auth, cfg); err != nil {
+		failf("failed to setup auth err=%v", err)
+	}
 
 	if cmd.client, err = sarama.NewClient(cmd.brokers, cfg); err != nil {
 		failf("failed to create client err=%v", err)


### PR DESCRIPTION
Some Kafka clusters use TLS as a backdoor load-balancing mechanism, see e.g. [strimzi's ingress feature](https://strimzi.io/blog/2019/05/23/accessing-kafka-part-5/). These are impossible to use with kt if the cluster uses a self-signed certificate, as it uses a default tls.Config in 1-way TLS mode. This PR adds the following features:

- use ca-certificate if provided even in 1-way TLS mode
- raise authentication errors in `group` and `topic` commands, rather than silently falling back to an unencrypted connection